### PR TITLE
Configurable Sidebar Position

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,10 @@
   "root": "./docs",
   "expanded": true,
   "logo": "./logo.png",
-  "defaultDepth": 3,
   "showLineNumbers": true,
-  "highlighter": "prism"
+  "highlighter": "prism",
+  "sidebar": {
+    "defaultDepth": 3,
+    "position": "left"
+  }
 }

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -2,21 +2,38 @@
 
 By default GitDocs will automatically generate the navigation based on your `/docs` folder structure.
 
-## Custom
+## Options
+
+The sidebar configuration supports the following options:
+
+```javascript
+{
+  // Number of levels of the navigation will be expanded by default
+  defaultDepth: 2,
+
+  // Location of the sidebar. Either "left" or "right"
+  position: "left",
+}
+```
+
+## Custom Structuure
 
 We recommend configuring the sidebar navigation in `docs.json` like so:
 
 ```json
 {
   "sidebar": {
-    "Introduction": "README.md",
-    "Quickstart": "quickstart.md",
-    "Writing": {
-      "markdown": "markdown/markdown.md",
-      "syntax": "syntax/code/languagues.md",
-      "Components": {
-        "helpers": "helpers.md",
-        "custom": "components/readme.md"
+    "position": "left",
+    "items": {
+      "Introduction": "README.md",
+      "Quickstart": "quickstart.md",
+      "Writing": {
+        "markdown": "markdown/markdown.md",
+        "syntax": "syntax/code/languagues.md",
+        "Components": {
+          "helpers": "helpers.md",
+          "custom": "components/readme.md"
+        }
       }
     }
   }
@@ -25,10 +42,4 @@ We recommend configuring the sidebar navigation in `docs.json` like so:
 
 You can infinitely nest folders, although we recommend limiting this to 2 or 3 levels otherwise navigating can become tedious and it's more difficult to visualize the hierarchy.
 
-You can also set the default depth of the navigation like so:
-
-```json
-defaultDepth: 2
-```
-
-which means that that many levels of the navigation will be expanded by default.
+You can use the `defaultDepth` option to control how many levels of the navigation will be expanded by default.

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -16,7 +16,7 @@ The sidebar configuration supports the following options:
 }
 ```
 
-## Custom Structuure
+## Custom Structure
 
 We recommend configuring the sidebar navigation in `docs.json` like so:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,33 +7,36 @@
   "cover": "docs-cover.png",
   "repository": "https://github.com/timberio/gitdocs",
   "license": "MIT",
-  "defaultDepth": 2,
   "languages": ["jsx", "bash", "json", "ocaml"],
   "highlighter": "highlight",
   "theme": "atom-one-light",
   "showLineNumbers": true,
   "sidebar": {
-    "Introduction": "README.md",
-    "Quickstart": "quickstart.md",
-    "writing": {
-      "Markdown": "markdown/markdown.md",
-      "Syntax": "syntax/languages.md",
-      "Table of contents": "writing/table-of-contents.md"
-    },
-    "components": {
-      "Helpers": "components/helpers.md",
-      "Custom": "components/custom.md"
-    },
-    "configuration": {
-      "Sidebar": "configuration/sidebar.md",
-      "Styles": "configuration/styles.md",
-      "Scripts": "configuration/scripts.md"
-    },
-    "deploying": {
-      "Github": "deploying/github.md",
-      "Gitlab": "deploying/gitlab.md",
-      "Netlify": "deploying/netlify.md"
-    },
-    "Development": "development.md"
+    "defaultDepth": 2,
+    "position": "left",
+    "items": {
+      "Introduction": "README.md",
+      "Quickstart": "quickstart.md",
+      "writing": {
+        "Markdown": "markdown/markdown.md",
+        "Syntax": "syntax/languages.md",
+        "Table of contents": "writing/table-of-contents.md"
+      },
+      "components": {
+        "Helpers": "components/helpers.md",
+        "Custom": "components/custom.md"
+      },
+      "configuration": {
+        "Sidebar": "configuration/sidebar.md",
+        "Styles": "configuration/styles.md",
+        "Scripts": "configuration/scripts.md"
+      },
+      "deploying": {
+        "Github": "deploying/github.md",
+        "Gitlab": "deploying/gitlab.md",
+        "Netlify": "deploying/netlify.md"
+      },
+      "Development": "development.md"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chalk": "^2.3.0",
     "classnames": "^2.2.5",
     "directory-tree": "^2.0.0",
+    "lodash.merge": "^4.6.0",
     "nprogress": "^0.2.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -62,21 +62,29 @@ class App extends Component {
 
   render () {
     const { tree, toc, config } = this.props
+    const sideBarRight = config.sidebar && config.sidebar.position === 'right'
+    const sidebar = (
+      <Sidebar
+        tree={tree}
+        toc={toc}
+        config={config}
+        sidebarIsOpen={this.state.sidebarIsOpen}
+      />
+    )
+    const toggle = (
+      <Toggle
+        onClick={this.handleSidebarToggle}
+        sidebarIsOpen={this.state.sidebarIsOpen}
+        position={config.sidebar.position}
+      />
+    )
 
     return (
       <Router>
         <Wrapper>
-          <Sidebar
-            tree={tree}
-            toc={toc}
-            config={config}
-            sidebarIsOpen={this.state.sidebarIsOpen}
-          />
-          <Toggle
-            onClick={this.handleSidebarToggle}
-            sidebarIsOpen={this.state.sidebarIsOpen}
-          />
+          {!sideBarRight && [sidebar, toggle]}
           <Routes />
+          {sideBarRight && [toggle, sidebar]}
         </Wrapper>
       </Router>
     )

--- a/src/components/Sidebar/Wrapper.js
+++ b/src/components/Sidebar/Wrapper.js
@@ -7,9 +7,15 @@ export default styled.aside`
   max-width: ${props => props.sidebarIsOpen ? '280px' : '0'};
   background: #f4f7fa;
   overflow-y: auto;
-  border-right: 1px solid #DFE3E8;
   margin: 0;
   z-index: 99;
+
+  ${props => {
+    if (props.position === 'left') {
+      return css`border-right: 1px solid #DFE3E8;`
+    }
+    return css`border-left: 1px solid #DFE3E8;`
+  }}
 
   @media(max-width: 700px) {
     width: 0;
@@ -18,7 +24,7 @@ export default styled.aside`
   ${props => props.sidebarIsOpen && css`
     @media(max-width: 700px) {
       position: fixed;
-      left: 0;
+      ${props => props.position === 'left' ? css`left: 0;` : css`right: 0;`}
       top: 0;
       bottom: 0;
     }

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -6,7 +6,7 @@ import Wrapper from './Wrapper'
 import Header from './Header'
 
 const Sidebar = ({ tree, toc, doc, config, sidebarIsOpen }) => (
-  <Wrapper sidebarIsOpen={sidebarIsOpen} className="sidebar">
+  <Wrapper sidebarIsOpen={sidebarIsOpen} className="sidebar" position={config.sidebar.position}>
     <Header>
       <a href={config.repository}>
         {config.name} version {config.version}

--- a/src/elements/Toggle.js
+++ b/src/elements/Toggle.js
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
   border: 1px solid #ddd;
   position: relative;
   top: 15px;
-  left: 15px;
+  ${props => props.position === 'right' ? css`right: 15px;` : css`left: 15px;` }
   cursor: pointer;
   border-radius: 4px;
   display: flex;
@@ -25,12 +25,12 @@ const Wrapper = styled.div`
   }
 
   @media (max-width: 720px) {
-    float: left;
+    ${props => props.position === 'left' ? css`float: left;` : css`float: right;`}
   }
 
   ${props => props.sidebarIsOpen && css`
     @media (max-width: 720px) {
-      left: 190px;
+      ${props => props.position === 'left' ? css`left: 245px;` : css`right: 245px;`}
       top: 6px;
     }
   `}

--- a/static.config.js
+++ b/static.config.js
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import merge from 'lodash.merge'
 import path from 'path'
 import React, { Component } from 'react'
 import { ServerStyleSheet } from 'styled-components'
@@ -38,11 +39,7 @@ try {
 }
 
 // Merge docs.json config with default config.json
-// TODO: make this a deep merge
-const config = {
-  ...defaults,
-  ...custom,
-}
+const config = merge(defaults, custom)
 
 if (config.theme) {
   if (config.highlighter === 'prism') {

--- a/static.config.js
+++ b/static.config.js
@@ -38,6 +38,7 @@ try {
 }
 
 // Merge docs.json config with default config.json
+// TODO: make this a deep merge
 const config = {
   ...defaults,
   ...custom,
@@ -51,7 +52,7 @@ if (config.theme) {
   }
 }
 
-if (!config.sidebar) {
+if (!config.sidebar || !config.sidebar.items) {
   // Pull out the markdown files in the /docs directory
   tree = dirTree(DOCS_SRC, { extensions: /\.md/ }, item => {
     const contents = fs.readFileSync(item.path, 'utf8')
@@ -121,8 +122,8 @@ function buildTree (item, name, current) {
   return child
 }
 
-if (config.sidebar) {
-  tree = buildTree(config.sidebar, '', '')
+if (config.sidebar && config.sidebar.items) {
+  tree = buildTree(config.sidebar.items, '', '')
 }
 
 // Generate docs routes


### PR DESCRIPTION
Allows configuration of the sidebar position using a `sidebar.position` option in the config file. The option has two valid values: `'left'` and `'right'`.

## Configuration Changes
The old sidebar configuration looked like
```json
{
  "sidebar": {
    "Item1": "item1.md",
    "Item2": "item2.md"
  }
}
```

However, this does not support including sidebar options under the `sidebar` key. This PR changes the sidebar config to:

```json
{
  "sidebar": {
    "defaultDepth": 2,
    "position": "right",
    "items": {
      "Item1": "item1.md",
      "item2": "item2.md"
    }
  }
}
```

## New Dependencies
This PR adds a dependency on `lodash.merge` to deep merge the config now that defaults can be nested. A simple object spread would not work.

## Issues Resolved
While implementing this I noticed that the toggle button was hidden by the sidebar on a mobile layout. Resolving this meant moving it further from the edge of the screen to account for the width of the sidebar. A possible future feature is a configurable sidebar width. 

## Left Sidebar Look
![screen shot 2017-12-15 at 5 05 51 pm](https://user-images.githubusercontent.com/6757853/34062523-f58f5018-e1ba-11e7-92f1-b3e6d47f5b03.png)
![screen shot 2017-12-15 at 5 06 03 pm](https://user-images.githubusercontent.com/6757853/34062530-fe161276-e1ba-11e7-821d-e85925cc8db9.png)
![screen shot 2017-12-15 at 5 06 10 pm](https://user-images.githubusercontent.com/6757853/34062531-fe287876-e1ba-11e7-9b09-804220aa565f.png)


## Right Sidebar Look
![screen shot 2017-12-15 at 5 06 44 pm](https://user-images.githubusercontent.com/6757853/34062538-08ccf946-e1bb-11e7-8534-f8a738fdaf44.png)
![screen shot 2017-12-15 at 5 06 51 pm](https://user-images.githubusercontent.com/6757853/34062539-08dd6876-e1bb-11e7-9ad6-2a38210ff236.png)
![screen shot 2017-12-15 at 5 07 02 pm](https://user-images.githubusercontent.com/6757853/34062540-08eca03e-e1bb-11e7-9644-94323b8a6c6f.png)
