### PR TITLE
Allow passing a version on the command line

### DIFF
--- a/bin/gitdocs.js
+++ b/bin/gitdocs.js
@@ -50,6 +50,13 @@ var argv = yargs
         nargs: 1,
         requiresArg: true,
         type: 'string'
+      },
+      'version': {
+        alias: 'v',
+        desc: chalk.gray('build.version'),
+        nargs: 1,
+        requiresArg: false,
+        type: 'string'
       }
     }),
     handler: argv => {
@@ -58,7 +65,8 @@ var argv = yargs
         `cd node_modules/gitdocs && node_modules/react-static/bin/react-static build`,
         {
           env: Object.assign({
-            GITDOCS_CWD: cwd
+            GITDOCS_CWD: cwd,
+            version: argv.version,
           }, process.env),
           stdio: [1,2,3]
         }

--- a/static.config.js
+++ b/static.config.js
@@ -39,7 +39,12 @@ try {
 }
 
 // Merge docs.json config with default config.json
-const config = merge(defaults, custom)
+// Dynamic options come from the command line
+// and override values in the config file
+const dynamicOptions = {
+  version: process.env.version,
+}
+const config = merge(defaults, custom, dynamicOptions)
 
 if (config.theme) {
   if (config.highlighter === 'prism') {


### PR DESCRIPTION
Adds a new command line option to the `build` command. This command now takes a `version` option that overrides the version field in the config.

@zsherman not sure the best way to test this. if you've got ideas, let me know.