### PR TITLE
lint command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/**/*.js
+docs-dist/**/*.js

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "react-static start",
     "build": "react-static build",
-    "serve": "serve dist -p 3000"
+    "serve": "serve dist -p 3000",
+    "lint": "eslint . -c .eslintrc.js"
   },
   "dependencies": {
     "chalk": "^2.3.0",


### PR DESCRIPTION
Adds a command to run `eslint` and ignores the output in `dist` and `docs-dist`.