### PR TITLE
Build command needs to find the `dist` dir in the GitDocs folder not the local project

### DIFF
--- a/bin/gitdocs.js
+++ b/bin/gitdocs.js
@@ -89,7 +89,7 @@ var argv = yargs
         }
       )
 
-      const distDir = path.join(cwd, 'dist')
+      const distDir = path.join(reactStaticWorkDir, 'dist')
       fs.copySync(distDir, argv.output)
     }
   })

--- a/static.config.js
+++ b/static.config.js
@@ -174,13 +174,13 @@ export default {
   onStart: () => {
     fs.copySync(
       path.resolve(DOCS_SRC, 'public'),
-      path.resolve(ROOT, 'dist'),
+      path.resolve(process.cwd(), 'dist'),
     )
   },
   onBuild: () => {
     fs.copySync(
       path.resolve(DOCS_SRC, 'public'),
-      path.resolve(ROOT, 'dist'),
+      path.resolve(process.cwd(), 'dist'),
     )
   },
   Document: class CustomHtml extends Component {


### PR DESCRIPTION
Noticed this problem when I was writing a deploy command. Wasn't noticed when building gitdocs itself because the output root and the run directory were the same.