### PR TITLE
Serve command path option implementation

### DIFF
--- a/bin/gitdocs.js
+++ b/bin/gitdocs.js
@@ -6,6 +6,7 @@ const fs = require('fs-extra')
 const inquirer = require('inquirer')
 const isGlobal = require('is-global')
 const merge = require('lodash.merge')
+const serve = require('serve')
 const path = require('path')
 const yargs = require('yargs')
 
@@ -52,24 +53,32 @@ var argv = yargs
     alias: 's',
     desc: chalk.gray('serve'),
     builder: yargs => yargs.options({
-      'port': {
-        alias: 'p',
+      port: {
+        alias: 'P',
         default: 3000,
-        desc: chalk.gray('serve.port'),
+        desc: chalk.gray('Port to use. Only applies if a path is specified.'),
         nargs: 1,
         requiresArg: true,
         type: 'number'
       }
     }),
     handler: argv => {
-      execSync(
-        `${reactStatic} start`,
-        {
-          cwd: reactStaticWorkDir,
-          env: Object.assign({ GITDOCS_CWD: cwd }, process.env),
-          stdio: [1,2,3]
-        }
-      )
+      if (argv.path) {
+        console.log(chalk.green(`Serving ${argv.path}`))
+        serve(argv.path, {
+          port: argv.port,
+        })
+      } else {
+        console.log('No path specified. Falling back to react-static dev server.')
+        execSync(
+          `${reactStatic} start`,
+          {
+            cwd: reactStaticWorkDir,
+            env: Object.assign({ GITDOCS_CWD: cwd }, process.env),
+            stdio: [1,2,3]
+          }
+        )
+      }
     }
   })
   .command({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10608,7 +10608,6 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/serve/-/serve-6.4.3.tgz",
       "integrity": "sha512-oD2sedcq5kvjhGdkA78xJFe9lczWx+Bw5ZQIoNkMGDpNMrgnh55yx2PwF2vBeAWZw3+W1Xnz5PpuMxEOdwV+Bg==",
-      "dev": true,
       "requires": {
         "args": "3.0.8",
         "basic-auth": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "remark-parse": "^4.0.0",
     "remark-rehype": "^2.0.1",
     "remark-toc": "^4.0.1",
+    "serve": "^6.1.0",
     "styled-components": "2.2.0",
     "unified": "^6.1.6",
     "yargs": "^10.0.3"
   },
   "devDependencies": {
-    "eslint-config-react-tools": "1.x.x",
-    "serve": "^6.1.0"
+    "eslint-config-react-tools": "1.x.x"
   },
   "bin": {
     "gitdocs": "bin/gitdocs.js"


### PR DESCRIPTION
`gitdocs serve` takes a positional path argument. If that argument is specified, we serve that directly. If it is not specified, the `react-static` dev server is used.