### PR TITLE
Fix broken minification during `gitdocs build`

### DIFF
--- a/docs/components/mermaid.md
+++ b/docs/components/mermaid.md
@@ -1,0 +1,81 @@
+# Mermaid JS Integration
+
+GitDocs supports native integration of [Mermaid](https://mermaidjs.github.io/) diagrams using the `<Mermaid>` tag in your markdown files. Mermaid can be used to generate Gantt charts, flowcharts, and even Git branching diagrams.
+
+```markdown
+<Mermaid>
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+</Mermaid>
+```
+
+<Mermaid>
+gantt
+    title Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+</Mermaid>
+
+## Configuring Sizes
+
+The `<Mermaid>` component supports `width` and `height` attributes to override the size of the diagram SVG. 
+
+```markdown
+<Mermaid width="400px">
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+</Mermaid>
+```
+
+<Mermaid width=400>
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+</Mermaid>
+
+## Custom Configs
+
+Each Mermaid diagram is highly customizable. The `<Mermaid>` component takes an option `config` parameter that points to an object with the properties you want to configure.
+
+```markdown
+<Mermaid config={ barGap: 10 }>
+
+</Mermaid>
+```
+
+<Mermaid config={ barGap: 10 }>
+gantt
+    title A Gantt Diagram
+    dateFormat  YYYY-MM-DD
+    section Section
+    A task           :a1, 2014-01-01, 30d
+    Another task     :after a1  , 20d
+    section Another
+    Task in sec      :2014-01-12  , 12d
+    another task      : 24d
+</Mermaid>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -26,7 +26,8 @@
       },
       "Components": {
         "Helpers": "components/helpers.md",
-        "Custom": "components/custom.md"
+        "Custom": "components/custom.md",
+        "Mermaid JS": "components/mermaid.md"
       },
       "Configuration": {
         "Sidebar": "configuration/sidebar.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2882,6 +2882,31 @@
         "es5-ext": "0.10.37"
       }
     },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
+    "dagre-d3-renderer": {
+      "version": "0.4.25",
+      "resolved": "https://registry.npmjs.org/dagre-d3-renderer/-/dagre-d3-renderer-0.4.25.tgz",
+      "integrity": "sha512-eUwgOTNZgYlUeU/DgEUdfu/bB/Oc6B1WpZCdW3LGTz/tpN34eeYw3YIDqPwHML6oZveM6lL/RNkMNUX9/aVfEg==",
+      "requires": {
+        "d3": "3.5.17",
+        "dagre-layout": "0.8.0",
+        "graphlib": "2.1.1",
+        "lodash": "4.17.4"
+      }
+    },
+    "dagre-layout": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dagre-layout/-/dagre-layout-0.8.0.tgz",
+      "integrity": "sha512-vK4WiR6h3whkoW9aM/FCjZTTx10V2YnLOLEj2+uvOQmiEjGmUvkme+Qrjj/7Tq0+AI54yFHT/tbbqM9AadsK4A==",
+      "requires": {
+        "graphlib": "2.1.1",
+        "lodash": "4.17.4"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -5597,6 +5622,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "graphlib": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.1.tgz",
+      "integrity": "sha1-QjUsUrovTQNctWbrkfc5X3bryVE=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -7838,6 +7871,19 @@
         "readable-stream": "2.3.3"
       }
     },
+    "mermaid": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-7.1.1.tgz",
+      "integrity": "sha512-cad/v0xUVnSEX2mkwT+Uf9QyKBGAL1VSpTrW5IXxIhcs1b5nrOnHq/rKEV5uwEXqsaUoDxzTsRHIqJf1cudaRw==",
+      "requires": {
+        "d3": "3.5.17",
+        "dagre-d3-renderer": "0.4.25",
+        "dagre-layout": "0.8.0",
+        "he": "1.1.1",
+        "lodash": "4.17.4",
+        "moment": "2.20.1"
+      }
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -7952,6 +7998,11 @@
       "requires": {
         "minimist": "0.0.8"
       }
+    },
+    "moment": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "mri": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "inquirer": "^4.0.1",
     "is-global": "^0.1.0",
     "lodash.merge": "^4.6.0",
+    "mermaid": "^7.1.1",
     "nprogress": "^0.2.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/src/components/Markdown/Mermaid.js
+++ b/src/components/Markdown/Mermaid.js
@@ -1,0 +1,68 @@
+import merge from 'lodash.merge'
+import mermaid, { mermaidAPI } from 'mermaid';
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import styled, { css } from 'styled-components'
+
+const Wrapper = styled.div`
+  width: ${props => props.width}px;
+  ${props => props.height ? css`height: ${props.height}px;` : ''}
+
+  svg {
+    height: 100%;
+    width: 100%;
+  }
+`
+
+class Mermaid extends Component {
+  state = {
+    diagram: ''
+  }
+
+  componentDidMount() {
+    const { children, config, height, width } = this.props
+    const defaultConfig = {
+      // If this is true, mermaid tries to re-render
+      // using window.addEventListener('loaded', ...)
+      // which screws it all up. 
+      startOnLoad: false,
+      gantt: {
+        useWidth: width,
+        useHeight: height ? height : null,
+      },
+    }
+    const mermaidConfig = merge(defaultConfig, config)
+    mermaidAPI.initialize(mermaidConfig)
+
+    const doc = children.toString().trim()
+    const diagram = mermaidAPI.render(doc)
+    this.setState({
+      diagram,
+    })
+  }
+
+  render() {
+    const { height, width } = this.props
+    return (<Wrapper
+        dangerouslySetInnerHTML={{ __html: this.state.diagram }}
+        height={height}
+        width={width}
+      >
+      </Wrapper>
+    )
+  }
+}
+
+Mermaid.propsTypes = {
+  config: PropTypes.object,
+  height: PropTypes.number,
+  width: PropTypes.number,
+}
+
+Mermaid.defaultProps = {
+  config: {},
+  height: null,
+  width: 800
+}
+
+export default Mermaid

--- a/src/components/Markdown/index.js
+++ b/src/components/Markdown/index.js
@@ -19,6 +19,7 @@ import InfoRenderer from './Info'
 import WarningRenderer from './Warning'
 import DangerRenderer from './Danger'
 import HighlightRenderer from './Highlight'
+import Mermaid from './Mermaid'
 // import Contents from './Contents'
 
 const makeComponents = options => ({
@@ -31,6 +32,7 @@ const makeComponents = options => ({
   highlight: HighlightRenderer,
   code: CodeRenderer(options),
   pre: PreRenderer(options),
+  mermaid: Mermaid,
 })
 
 const linkHAST = {

--- a/static.config.js
+++ b/static.config.js
@@ -209,4 +209,25 @@ export default {
       )
     }
   },
+  webpack: (config, { defaultLoaders }) => {
+    // We replace the existing JS rule with one, that also transforms from
+    // remark-collapse
+    config.module.rules = [{
+      oneOf: [
+        {
+          test: /\.(js|jsx)$/,
+          // remark-collapse has ES6 so we need to babel it
+          exclude: new RegExp(`${defaultLoaders.jsLoader.exclude}/(?!(remark-collapse)\/)`),
+          use: [
+            {
+              loader: 'babel-loader',
+            },
+          ],
+        },
+        defaultLoaders.cssLoader,
+        defaultLoaders.fileLoader,
+      ],
+    }]
+    return config
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,11 +2078,31 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+d3@3.5.17:
+  version "3.5.17"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-3.5.17.tgz#bc46748004378b21a360c9fc7cf5231790762fb8"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
   dependencies:
     es5-ext "^0.10.9"
+
+dagre-d3-renderer@^0.4.25:
+  version "0.4.25"
+  resolved "https://registry.yarnpkg.com/dagre-d3-renderer/-/dagre-d3-renderer-0.4.25.tgz#9eec8e63854394b3567c51f2b1d0c8137919a18d"
+  dependencies:
+    d3 "3.5.17"
+    dagre-layout "^0.8.0"
+    graphlib "^2.1.1"
+    lodash "^4.17.4"
+
+dagre-layout@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/dagre-layout/-/dagre-layout-0.8.0.tgz#7147b6afb655602f855158dfea171db9aa98d4ff"
+  dependencies:
+    graphlib "^2.1.1"
+    lodash "^4.17.4"
 
 damerau-levenshtein@^1.0.0:
   version "1.0.4"
@@ -3400,6 +3420,12 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphlib@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/graphlib/-/graphlib-2.1.1.tgz#42352c52ba2f4d035cb566eb91f7395f76ebc951"
+  dependencies:
+    lodash "^4.11.1"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -3589,7 +3615,7 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
-he@1.1.x:
+he@1.1.x, he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
@@ -4824,7 +4850,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5007,6 +5033,17 @@ merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
+mermaid@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-7.1.1.tgz#b013cfb807eea90087ead88bc8c1cd75baf95e71"
+  dependencies:
+    d3 "3.5.17"
+    dagre-d3-renderer "^0.4.25"
+    dagre-layout "^0.8.0"
+    he "^1.1.1"
+    lodash "^4.17.4"
+    moment "^2.20.1"
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -5120,6 +5157,10 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+moment@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
 mri@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
`gitdocs build` now generates minified output. The problem was that the `remark-collapse` lib has ES6, but react-static excludes `node_modules` from babel. This change forces babel to transpile `node_modules/remark-collapse` as well.