### PR TITLE
Remove current project version from the sidebar

### DIFF
--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -16,7 +16,7 @@ export default function Sidebar ({ tree, config, sidebarIsOpen, onSidebarToggle 
       <div className="inner">
         <Header position={config.sidebar.position}>
           <span>
-            <a href={config.repository}>{config.name}</a> <span>v. {config.version}</span>
+            <a href={config.repository}>{config.name}</a>
           </span>
         </Header>
         <ul>{tree.map(item => <SidebarItem item={item} key={item.name} config={config} />)}</ul>


### PR DESCRIPTION
Without the ability to switch versions, showing the latest version of a project brings minimal use.

It has a cost, though. Because we track the latest changes on the master branch, we might be showing in the documentation new features that have not yet been released, yet the version indicator in the corner implies they are, misleading the users.

Ultimately this problem is caused by npm’s package.json insistence on keeping the version field inside the configuration, where it usually has no meaning. After all, for all non-release commits the package.json version is lying.

This just bit me when I saw [new features](https://github.com/nozzle/react-static/pull/446/commits/08884a7924361c4637aad20fd032a4206471a9f6) in react-static docs, and the docs said 5.5.13, but my 5.5.13 did not want to enable these features. Well, but 5.5.13 does not actually has these features yet!