### PR TITLE
WIP feat: Support custom theme

### DIFF
--- a/src/core/compiler.js
+++ b/src/core/compiler.js
@@ -3,7 +3,6 @@ const webpack = require('webpack')
 const ProgressPlugin = require('webpack/lib/ProgressPlugin')
 const { babelOptions } = require('../utils/babel')
 
-const THEMES_DIR = syspath.resolve(__dirname, '../../themes')
 const NODE_MODS_DIR = syspath.resolve(__dirname, '../../node_modules')
 
 async function getCompiler (env, props) {
@@ -18,7 +17,7 @@ async function getCompiler (env, props) {
     entry: {
       main: [
         isDev && 'webpack-hot-middleware/client',
-        `${THEMES_DIR}/${props.config.theme}/index.js`,
+        `${props.config.theme}/index.js`,
       ].filter(Boolean),
     },
     output: {
@@ -38,7 +37,7 @@ async function getCompiler (env, props) {
       rules: [
         {
           test: /\.js$/,
-          include: THEMES_DIR,
+          include: syspath.dirname(props.config.theme),
           exclude: NODE_MODS_DIR,
           use: {
             loader: 'babel-loader',

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -28,7 +28,7 @@ const DEFAULT_CONFIG = {
   port: 8000,
   languages: ['bash', 'json'],
   header_links: [],
-  theme: 'default',
+  theme: '~default',
   breadcrumbs: true,
   prefix_titles: false,
   table_of_contents: {
@@ -65,6 +65,28 @@ function getExternalConfig (dir, name) {
   return file ? readConfigFile(file) : {}
 }
 
+function resolveThemeDirectory (config) {
+  const theme = config.theme
+  if (theme.indexOf('/') === 0) {
+    return theme
+  } else if (theme.indexOf('.') === 0) {
+    // local path
+    return syspath.resolve(
+      config.root,
+      theme
+    )
+  } else if (theme.indexOf('~') === 0) {
+    // gitdocs built-in theme
+    return syspath.resolve(
+      __dirname,
+      '../../themes',
+      theme.substr(1)
+    )
+  }
+  // package theme
+  return require.resolve(theme)
+}
+
 async function getConfig (customFile) {
   // prioritize custom config file if passed,
   // but still fallback to default files
@@ -93,6 +115,8 @@ async function getConfig (customFile) {
     masterConfig.root,
     masterConfig.static,
   )
+
+  masterConfig.theme = resolveThemeDirectory(masterConfig)
 
   return masterConfig
 }

--- a/themes/server.js
+++ b/themes/server.js
@@ -2,8 +2,7 @@ import React from 'react'
 import { StaticRouter } from 'react-router-dom'
 
 export default function (props, route) {
-  const { theme } = props.config
-  const { default: App } = require(`./${theme}/application`)
+  const App = require(`${props.config.theme}/application`).default
 
   return (
     <StaticRouter


### PR DESCRIPTION
With this change, it is possible to use a theme : 

- From a built-in gitdocs theme (default for the moment)
- From a npm package
- From a local to the docs directory

To support this, the theme is resolved as early as possible either with syspath.resolve or with require.resolve.

I haven't completely tested this change (default works, custom works but I haven't tested the npm package way), I mainly want to check if this is the direction you want for the themes. What do you think ?
