### PR TITLE
[Feature] buildForRoot flag, determines if the build should be relative or absolute

### DIFF
--- a/src/core/hydrate.js
+++ b/src/core/hydrate.js
@@ -161,7 +161,12 @@ async function hydrateTree (tree, config, opts = {}) {
     // only files should have an input and output value
     if (hoistedItem.type === 'file') {
       hydratedItem.input = hoistedItem.path
-      hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url)
+
+      if(!config.buildForRoot && config.baseURL) {
+        hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url.substring(config.baseURL.length + 1))
+      } else {
+        hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url)
+      }
 
       // pull in source items if one exists
       if (metaData.source) {

--- a/src/core/hydrate.js
+++ b/src/core/hydrate.js
@@ -162,7 +162,7 @@ async function hydrateTree (tree, config, opts = {}) {
     if (hoistedItem.type === 'file') {
       hydratedItem.input = hoistedItem.path
 
-      if(!config.buildForRoot && config.baseURL) {
+      if (!config.buildForRoot && config.baseURL) {
         hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url.substring(config.baseURL.length + 1))
       } else {
         hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url)

--- a/src/core/hydrate.js
+++ b/src/core/hydrate.js
@@ -163,7 +163,9 @@ async function hydrateTree (tree, config, opts = {}) {
       hydratedItem.input = hoistedItem.path
 
       if (!config.buildForRoot && config.baseURL) {
-        hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url.substring(config.baseURL.length + 1))
+        hydratedItem.outputDir = syspath.join(
+          config.output,
+          hydratedItem.url.substring(config.baseURL.length + 1))
       } else {
         hydratedItem.outputDir = syspath.join(config.output, hydratedItem.url)
       }

--- a/src/core/template.js
+++ b/src/core/template.js
@@ -6,12 +6,19 @@ const { Helmet } = require('react-helmet')
 const { hijackConsole } = require('../utils/emit')
 const babelRequire = require('../utils/babel')
 
-function getScriptTags (entrypoints) {
+function getScriptTags (entrypoints, props) {
   const files = entrypoints.main.assets
 
   return files
     .filter(bundle => syspath.extname(bundle) === '.js')
-    .map(bundle => `<script type="text/javascript" src="/${bundle}"></script>`)
+    .map(bundle => {
+      let constructedBundleURL = bundle
+      if (process.env.NODE_ENV === 'production' && (!props.config.buildForRoot && props.config.baseURL)) {
+        constructedBundleURL = `${props.config.baseURL}/${bundle}`
+      }
+
+      return `<script type="text/javascript" src="/${constructedBundleURL}"></script>`
+    })
     .join('\n')
 }
 
@@ -57,7 +64,7 @@ function templateForProduction (entrypoints, props, route) {
         <div id="gitdocs-app">${rendered.html}</div>
 
         <script>window._EMOTION_IDS_ = ${JSON.stringify(rendered.ids)}</script>
-        ${getScriptTags(entrypoints)}
+        ${getScriptTags(entrypoints, props)}
       </body>
     </html>
   `

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -23,6 +23,7 @@ const DEFAULT_CONFIG = {
   logo: null,
   baseURL: '/',
   domain: '',
+  buildForRoot: true,
   crawlable: true,
   host: 'localhost',
   port: 8000,

--- a/themes/default/application/index.js
+++ b/themes/default/application/index.js
@@ -50,7 +50,7 @@ class App extends Component {
      * with the baseURL prepended in order to have a build that is relative to the baseURL.
      */
     let constructedLogoURL = config.logo
-    if (process.env.NODE_ENV !== 'development' && (!config.buildForRoot && config.baseURL)) {
+    if (process.env.NODE_ENV === 'production' && (!config.buildForRoot && config.baseURL)) {
       constructedLogoURL = `${config.baseURL}/${config.logo}`
     }
 

--- a/themes/default/application/index.js
+++ b/themes/default/application/index.js
@@ -44,6 +44,16 @@ class App extends Component {
       manifest,
     } = this.props
 
+    /**
+     * Determine if we are building for production, and have buildForRoot set to false, and
+     * the config contains a baseURL. If these conditions are met, we will build the logo URL
+     * with the baseURL prepended in order to have a build that is relative to the baseURL.
+     */
+    let constructedLogoURL = config.logo
+    if (process.env.NODE_ENV !== 'development' && (!config.buildForRoot && config.baseURL)) {
+      constructedLogoURL = `${config.baseURL}/${config.logo}`
+    }
+
     return (
       <ConfigContext.Provider value={config}>
         <Theme>
@@ -71,7 +81,7 @@ class App extends Component {
             <WrapperNav>
               <Sidebar
                 manifest={manifest}
-                customLogo={config.logo}
+                customLogo={constructedLogoURL}
               />
             </WrapperNav>
 

--- a/themes/default/search/index.js
+++ b/themes/default/search/index.js
@@ -60,7 +60,13 @@ class Search extends Component {
 
   async loadResults () {
     // Initialize search instance and set indices
-    const resp = await axios.get('/db.json')
+
+    let constructedRequestEndpoint = `/db.json`
+    if(process.env.NODE_ENV === 'production' && (!this.props.config.buildForRoot && this.props.config.baseURL)) {
+      constructedRequestEndpoint = `/${this.props.config.baseURL}/db.json`
+    }
+
+    const resp = await axios.get(constructedRequestEndpoint)
     this.db = createDB({
       ref: 'url',
       indices: ['title', 'content'],

--- a/themes/default/search/index.js
+++ b/themes/default/search/index.js
@@ -61,8 +61,8 @@ class Search extends Component {
   async loadResults () {
     // Initialize search instance and set indices
 
-    let constructedRequestEndpoint = `/db.json`
-    if(process.env.NODE_ENV === 'production' && (!this.props.config.buildForRoot && this.props.config.baseURL)) {
+    let constructedRequestEndpoint = '/db.json'
+    if (process.env.NODE_ENV === 'production' && (!this.props.config.buildForRoot && this.props.config.baseURL)) {
       constructedRequestEndpoint = `/${this.props.config.baseURL}/db.json`
     }
 


### PR DESCRIPTION
Hi team, I've built a feature that would generate the build with relative links to the web server root. This is helpful if you want to have multiple instances of gitdocs in different sub directories:

* https://example.com/docs/docs-site-1
* https://example.com/docs/docs-site-2

I think this is a huge advantage and would work perfectly with the repo.

This feature works by first setting the `buildForRoot` config flag to `false` (set to `true` by default, which is standard behavior), while also setting the `baseURL`.

This PR addresses #171 and #165 

Any feedback is welcome!

Blake