### PR TITLE
Add TOC max-depth custom config support & styling

### DIFF
--- a/docs/api/config-file.md
+++ b/docs/api/config-file.md
@@ -38,6 +38,7 @@ module.exports = new Promise((resolve, reject) => {
 | table\_of_contents | object | | |
 | table\_of_contents.page | boolean | `true` | Whether to enable the table of contents for headers in the page. |
 | table\_of_contents.folder | boolean | `true` | Whether to enable the table of contents for pages in a folder (shown in the [index page](/index-files).) |
+| table\_of_contents.max_depth | number | `2` | Defines a maximum header level depth to render in the TOC. |
 | syntax | object | | |
 | syntax.theme | string | `atom-one-light` | The [syntax highlighting theme](/syntax-highlighting/#choosing-a-style) to use. |
 | syntax.renderer | string | `hljs` | The [syntax highlighting renderer](/syntax-highlighting/#choosing-a-renderer) to use. Options are `hljs` or `prism`. |

--- a/src/core/hydrate.js
+++ b/src/core/hydrate.js
@@ -52,30 +52,30 @@ function normalizeItems (data) {
 
 async function tableOfContents (toc, { input, items }) {
   // only add items that have a file associated with it
-    if (input) {
-      if (toc.page) {
-        toc.page = markdownToc(await getContent(input))
-          .json.filter(i => i.lvl <= (toc.max_depth || DEFAULT_TOC_DEPTH))
-      }
-
-      if (toc.folder) {
-        toc.folder = items
-          // only want children items that have an input
-          .filter(item => item.input)
-          // reduced data, since we don't need everything
-          .map(item => ({
-            title: item.title,
-            description: item.description,
-            url: item.url,
-          }))
-      }
+  if (input) {
+    if (toc.page) {
+      toc.page = markdownToc(await getContent(input))
+        .json.filter(i => i.lvl <= (toc.max_depth || DEFAULT_TOC_DEPTH))
     }
 
-    // dont keep empty arrays
-    if (!toc.page || !toc.page.length) delete toc.page
-    if (!toc.folder || !toc.folder.length) delete toc.folder
+    if (toc.folder) {
+      toc.folder = items
+        // only want children items that have an input
+        .filter(item => item.input)
+        // reduced data, since we don't need everything
+        .map(item => ({
+          title: item.title,
+          description: item.description,
+          url: item.url,
+        }))
+    }
+  }
 
-    return toc
+  // dont keep empty arrays
+  if (!toc.page || !toc.page.length) delete toc.page
+  if (!toc.folder || !toc.folder.length) delete toc.folder
+
+  return toc
 }
 
 async function hydrateTree (tree, config, opts = {}) {

--- a/themes/default/markdown/overrides/Header.js
+++ b/themes/default/markdown/overrides/Header.js
@@ -48,7 +48,5 @@ export default function (props) {
 
   const element = React.createElement(levels[level], { style }, children)
 
-  return level <= 2
-    ? <Link href={`#${itemId}`} id={itemId}>{element}</Link>
-    : element
+  return <Link href={`#${itemId}`} id={itemId}>{element}</Link>
 }

--- a/themes/default/toc/page.js
+++ b/themes/default/toc/page.js
@@ -8,7 +8,7 @@ const Toc = (props) => {
 
   // Create TOC hierarchy and link to headers
   const items = props.items.map(t => (
-    <li key={`${props.items}-${t.slug}`}>
+    <li key={`${props.items}-${t.slug}`} className={`level-${t.lvl}`}>
       <a href={`#${t.slug}`}>
         {t.content}
       </a>
@@ -16,7 +16,7 @@ const Toc = (props) => {
   ))
 
   return (
-    <PageItem sticky={props.sticky}>
+    <PageItem sticky={props.sticky} items={props.items}>
       <div>
         <h5>Table of Contents</h5>
         <ul>{items}</ul>

--- a/themes/default/toc/styles.js
+++ b/themes/default/toc/styles.js
@@ -5,6 +5,10 @@ export const Wrapper = styled('nav')`
   margin: 60px 0 0 5px;
   position: relative;
 `
+const generateListItemLevels = items => items.map(({ lvl }) => `
+  li.level-${lvl} {
+    padding-left: ${(lvl - 1) * 8}px;
+  }`).join(' ')
 
 export const PageItem = styled('nav')`
   position: relative;
@@ -43,6 +47,8 @@ export const PageItem = styled('nav')`
     line-height: 30px;
     display: block;
   }
+
+  ${props => props.items && generateListItemLevels(props.items)}
 
   a {
     text-decoration: none;


### PR DESCRIPTION
**Issue:** 
Current implementation would render maximum header depth of 2 inside the TOC without an ability to customise that.
Headers with level > 2 were not being rendered nor linkable inside the TOC.

**Fix:**
- Added support for passing custom `max_depth` configuration in `.gitdocs.json` to allow overriding the default value.
- Added styling of nested headers inside the TOC

After:
![image](https://user-images.githubusercontent.com/43777855/67622485-31873880-f823-11e9-8175-2acc1ef2dc11.png)

Before (having headers in the `.md` file from `h1` to `h5`, it displays only level 1 & 2 without any visual indications of their level ):
![image](https://user-images.githubusercontent.com/43777855/67622510-73b07a00-f823-11e9-8923-fedf728f4728.png)