### PR TITLE
Fix Issue MarkdownWrapper 

### DIFF
--- a/themes/default/page/styles.js
+++ b/themes/default/page/styles.js
@@ -27,6 +27,10 @@ export const MarkdownWrapper = styled('div')`
   flex: 1;
   max-width: 850px;
 
+  @media(max-width: 1440px) {
+    max-width: 800px;
+  }
+
   @media(max-width: 1200px) {
     padding: 0 50px 0 0;
   }


### PR DESCRIPTION
**Issue**
In certain pages the markdownwrapper reaches the specified max-width of 850px.
This ends up forcing the parent div to wrap and overlap ToC div in windows under 1440px as seen in - thepracticaldev/dev.to#6922

![Screenshot from 2020-03-28 15-45-29](https://user-images.githubusercontent.com/35686547/77825684-2e161700-710b-11ea-857d-d6d1dbd2b248.png)

**Proposed solution**
In order to create a solution for this specific case and not change the current css or alter the visualization for bigger screens, I ended up just creating a media-query.




